### PR TITLE
Dockerfile & Python script

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+Dockerfile
+test_files
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+FROM ubuntu:20.04
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install tzdata
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get update && \
+    apt-get install -y build-essential libopencv-dev python3-opencv ffmpeg bc
+
+RUN apt-get update && \
+    apt-get install -y python3 python3-pip
+
+COPY requirements.txt .
+RUN pip3 install -r requirements.txt
+
+# Install gosu
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y gosu; \
+	rm -rf /var/lib/apt/lists/*; \
+# verify that the binary works
+	gosu nobody true
+
+RUN useradd app
+
+COPY src /app/src
+
+WORKDIR /app
+
+RUN mkdir PROCESSING_ZONE
+
+RUN cd src/disk && make
+RUN cd src/page && make
+RUN cd src/pymdb && python3 setup.py install
+
+COPY . /app
+
+RUN chown -R app:app /app
+
+ENV PYTHONUNBUFFERED 1
+
+ENTRYPOINT ["/app/docker-entrypoint.sh", "/app/movinyl.py"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+exec gosu "${RUN_AS:-1000:1000}" "$@"

--- a/movinyl.py
+++ b/movinyl.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+import os
+import shutil
+import subprocess
+import sys
+from os.path import splitext, basename, dirname
+
+import click
+import ffpb
+import magic
+import tqdm
+from PIL import Image
+
+from color_picker import get_points, kmeans
+
+
+@click.group()
+def main():
+    pass
+
+
+@main.command()
+@click.argument('dir', default="PROCESSING_ZONE")
+@click.option('--n', default=2000)
+def disk(dir, n):
+    files = os.listdir(dir)
+    print(sys.argv)
+    for file in files:
+        file_path = os.path.join(dir, file)
+
+        print(file_path)
+        if os.path.isdir(file_path):
+            continue
+
+        mime = magic.Magic(mime=True)
+        filename = mime.from_file(file_path)
+        if not filename.startswith('video/'):
+            continue
+
+        video_length = subprocess.check_output(['ffprobe', '-v', 'error', '-show_entries', 'format=duration', '-of',
+                                                'default=noprint_wrappers=1:nokey=1', file_path])
+        video_length = float(video_length)
+        r = 2005 / video_length
+        file_without_ext, _ = splitext(file_path)
+
+        output2 = os.path.join(file_without_ext, 'images', '%d.jpg')
+
+        ffmpeg_needed = False
+        for i in range(1, n + 1):
+            if not os.path.exists(output2 % i):
+                ffmpeg_needed = True
+
+        if ffmpeg_needed:
+            os.makedirs(os.path.join(file_without_ext, 'images'), exist_ok=True)
+            argv = [
+                '-y', '-i', file_path, '-r', str(r), '-qscale:v', '1',
+                '-f', 'image2', output2
+            ]
+
+            class ProgressBar(tqdm.tqdm):
+                def __init__(self, **kwargs):
+                    kwargs['desc'] = "Generating the snapshots..."
+                    super().__init__(**kwargs)
+
+            ffpb.main(argv, stream=sys.stdout, tqdm=ProgressBar)
+
+        images_folder = os.path.join(file_without_ext, 'images')
+        if not os.path.exists(images_folder):
+            print(f'no "images" folder ({images_folder}), re-run.')
+            return
+
+        name = basename(file_without_ext)
+        name = name.replace(' ', '_')
+        name = name.replace('-', '_')
+
+        file_underscores = os.path.join(dirname(file_path), f"{name}.png")
+
+        if os.path.exists(file_underscores):
+            print(f'OK {file_underscores}')
+            return
+
+        save_png = os.path.join(file_without_ext, 'save.png')
+        process = subprocess.Popen([os.path.join(os.getcwd(), 'src', 'disk', 'disk'), str(n)],
+                                   cwd=os.path.join(file_without_ext), stdout=subprocess.PIPE)
+
+        previous = 0
+        with tqdm.tqdm(total=n, desc="generating & merging disk images...") as pbar:
+            while process.poll() is None:
+                line = process.stdout.readline()
+                try:
+                    p = int(line)
+                    pbar.update(p - previous)
+                    previous = p
+                except ValueError:
+                    pass
+
+        shutil.move(save_png, file_underscores)
+
+
+@main.command()
+@click.argument('dir', default="PROCESSING_ZONE")
+def page(dir):
+    files = os.listdir(dir)
+    for file in files:
+        file_path = os.path.join(dir, file)
+
+        if os.path.isdir(file_path):
+            continue
+
+        mime = magic.Magic(mime=True)
+        filename = mime.from_file(file_path)
+        if not filename.startswith('video/'):
+            continue
+
+        file_without_ext, _ = os.path.splitext(file_path)
+        name = basename(file_without_ext)
+        name = name.replace(' ', '_')
+        name = name.replace('-', '_')
+        file_png = os.path.join(dirname(file_without_ext), f'{name}.png')
+
+        def colorz(filename, n=3):
+            img = Image.open(filename)
+            img.thumbnail((200, 200))
+            w, h = img.size
+
+            points = get_points(img)
+            clusters = kmeans(points, n, 1)
+            return [str(int(x)) for c in clusters for x in c.center.coords]
+
+        colors = colorz(file_png, 5)
+        popen = [os.path.join(os.getcwd(), 'src', 'page', 'page'), name] + colors
+        print(" ".join(popen))
+        subprocess.check_output([sys.executable, 'generate_infos.py', name])
+        shutil.move('titre.png', os.path.join(dir, 'titre.png'))
+        shutil.move('année.png', os.path.join(dir, 'année.png'))
+        shutil.move('réalisateur.png', os.path.join(dir, 'réalisateur.png'))
+        shutil.move('durée.png', os.path.join(dir, 'durée.png'))
+        subprocess.check_output(popen, cwd=dir)
+        os.remove(os.path.join(dir, 'titre.png'))
+        os.remove(os.path.join(dir, 'année.png'))
+        os.remove(os.path.join(dir, 'réalisateur.png'))
+        os.remove(os.path.join(dir, 'durée.png'))
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+PyQt5
+PyQt5-stubs
+Pillow
+python-magic
+click
+ffpb

--- a/src/disk/disk.cpp
+++ b/src/disk/disk.cpp
@@ -3,6 +3,7 @@
 #include <opencv2/highgui.hpp>
 #include <string>
 #include <omp.h>
+#include <iostream>
 using namespace cv;
 
 //some movies have a black border of a few pixels.
@@ -92,6 +93,7 @@ void GenerateDisk(int FrameNumber){
 
 int main(int argc, char const *argv[])
 {
+    setbuf(stdout, NULL);
 	GenerateDisk(atoi(argv[1]));
 	return 0;
 }


### PR DESCRIPTION
I may have been a bit overboard with the contribution there.

The included Dockerfile can generate the disk images as well as page images. Run `docker build -t movinyl .`, then 

- `docker run -v path-with-video-files:/app/PROCESSING_ZONE movinyl disk` will generate the disk images 
- `docker run -v path-with-video-files:/app/PROCESSING_ZONE movinyl page` makes the pages (with auto-generated palette colors, not sure how to fit the GUI color-selection in a Docker workflow)

The permission problem is side-stepped by using gosu and assuming the uid:gid of the host user is 1000:1000 (use `-e RUN_AS=uid:gud` otherwise), this way the files are written inside the mounted volume at /app/PROCESSING_ZONE without being owned by root.

I've regrouped a bunch of scripts into a single script movinyl.py without touching the rest, solving a few bugs along the way (* expansion, treating non-video files etc)
