### PR TITLE
Refactored OpenMP Implementation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "typeinfo": "cpp"
+    }
+}

--- a/movinyl.py
+++ b/movinyl.py
@@ -81,16 +81,14 @@ def disk(dir, n):
 
         save_png = os.path.join(file_without_ext, 'save.png')
         process = subprocess.Popen([os.path.join(os.getcwd(), 'src', 'disk', 'disk'), str(n)],
-                                   cwd=os.path.join(file_without_ext), stdout=subprocess.PIPE)
+                                   cwd=os.path.join(file_without_ext), stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
-        previous = 0
-        with tqdm.tqdm(total=n, desc="generating & merging disk images...") as pbar:
+        with tqdm.tqdm(total=n, desc="Generating and merging disk images...") as pbar:
             while process.poll() is None:
                 line = process.stdout.readline()
                 try:
                     p = int(line)
-                    pbar.update(p - previous)
-                    previous = p
+                    pbar.update(10)
                 except ValueError:
                     pass
 


### PR DESCRIPTION
- Removed old OpenMP directives 
- Removed parallelization from ExtractCircle() and Insert() methods as it slows it down. I believe these functions are so quick that the overhead of forking and joining threads may actually be slowing things down.
- Run GenerateDisk() with max number of threads dependent on hardware
- Use static scheduling of 1 to distribute work load equally since task gets easier each loop
- Each thread receives its own matrix to which it can independently write to (avoiding use of critical or locked regions). At the end, these matrices are merged using max() to obtain a final matrix of disks.